### PR TITLE
auto reload after creating a class

### DIFF
--- a/src/views/internals/PnlResources.java
+++ b/src/views/internals/PnlResources.java
@@ -7,6 +7,7 @@ package views.internals;
 import com.formdev.flatlaf.FlatClientProperties;
 import controllers.UserController;
 import enums.DialogAction;
+import enums.LayoutPage;
 import java.io.InputStream;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
@@ -305,6 +306,7 @@ public class PnlResources extends javax.swing.JPanel {
     private void btnAddActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddActionPerformed
 
         new DlgClass(AppLayout.appLayout, true).setVisible(true);
+        AppLayout.appLayout.changeForm(LayoutPage.RESOURCES);
     }//GEN-LAST:event_btnAddActionPerformed
 
     private void btnRefreshActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRefreshActionPerformed


### PR DESCRIPTION
This pull request introduces a minor update to the `PnlResources` class in the `src/views/internals` package. The changes include the addition of a new enum import and a call to update the application layout after a dialog is displayed.

### Key Changes:

#### Updates to `PnlResources` functionality:
* Added an import for the `LayoutPage` enum to support layout updates. (`src/views/internals/PnlResources.java`, [src/views/internals/PnlResources.javaR10](diffhunk://#diff-d305da1f9a1848a33cb8780afd9d1de4c1d828adb4bc6b8bb314a27e7d0894dbR10))
* Modified the `btnAddActionPerformed` method to include a call to `AppLayout.appLayout.changeForm(LayoutPage.RESOURCES)` after displaying the dialog, ensuring the layout updates to the `RESOURCES` page. (`src/views/internals/PnlResources.java`, [src/views/internals/PnlResources.javaR309](diffhunk://#diff-d305da1f9a1848a33cb8780afd9d1de4c1d828adb4bc6b8bb314a27e7d0894dbR309))